### PR TITLE
Use UMD bundled version for most basic example.

### DIFF
--- a/javascript/godirect-js-faqs.md
+++ b/javascript/godirect-js-faqs.md
@@ -6,7 +6,7 @@
 
 ## How do I get started with JavaScript?
 Here are some generally helpful links for getting started with JavaScript
-- [JavaScript Tutorial](https://www.w3schools.com/js/)
+- [JavaScript Tutorials](https://javascript.info/)
 
 ## Where can I find examples of using the godirect-js library?
 - Official examples that use godirect-js can be found in the Vernier [godirect-examples repository](./).

--- a/javascript/godirect-sensor-readout/index.html
+++ b/javascript/godirect-sensor-readout/index.html
@@ -4,7 +4,7 @@
   <title>Go Direct Sensor Readout</title>
   <meta name="description" content="Simple expample of connecting to a Vernier Go Direct® Sensor with WebBluetooth and logging out the default sensor value">
   <meta charset="utf-8">
-  <script type="module" src="https://unpkg.com/@vernier/godirect/dist/godirect.min.js"></script>
+  <script src="https://unpkg.com/@vernier/godirect/dist/godirect.min.umd.js"></script>
 </head>
 
 <body>
@@ -31,7 +31,7 @@
 
         enabledSensors.forEach(sensor => {
           sensor.on('value-changed', (sensor) => {
-            // Only collect 10 samples and disconnect. 
+            // Only collect 10 samples and disconnect.
             if (sensor.values.length > 10){
               gdxDevice.close();
             }


### PR DESCRIPTION
Removed link to w3schools. W3schools has a long time history of being the worst place to learn about JS. Updated it to something a little better.