### PR TITLE
Adding Josh's freebody diagram program.

### DIFF
--- a/python/advanced_examples/live_freebody_diagram.py
+++ b/python/advanced_examples/live_freebody_diagram.py
@@ -1,0 +1,85 @@
+'''
+This program takes advantage of the 3-axis accelerometer built into GDX-FOR. Using the accelerometer 
+values, the program creates a "live" freebody diagram for a ring with three forces acting on it:
+1) The force of a hanging mass, pulling downward on the ring
+2) The force of the GDX-FOR sensor, pulling up at an angle on the ring
+3) The force of a string, tied an upright ring stand and on the ring, also pulling up at an angle on the ring
+
+The resulting freebody diagram is "Y" shaped. As you run the program, move the GDX-FOR around. 
+The freebody diagram will update itself to reflect the GDX-FOR's current orientation and the force 
+exerted by its load cell.
+
+This program is written to connect to GDX-FOR via Bluetooth, and therefore requires the BlueGiga BLE dongle. 
+You can run the program connected to GDX-FOR via USB; just change line 25 to "gdx.open_usb".
+
+This program requires the godirect-py, vpython, and math packages.
+'''
+
+import os
+import sys
+
+# This allows us to import the local gdx module that is up one directory
+gdx_module_path = os.path.abspath(os.path.join('..'))
+if gdx_module_path not in sys.path:
+    sys.path.append(gdx_module_path)
+
+from gdx import gdx
+from vpython import *
+gdx = gdx.gdx()
+
+import math
+
+canvas(title='<b>Live Freebody Diagram<b>')
+
+hanging_mass=float(input("Enter the mass (in kg) of the hanging mass:"))    # prompts user for mass of hanging mass
+
+gdx.open_ble('GDX-FOR 07200362') # change GDX-FOR ID to match your device
+gdx.select_sensors([1,2,3,4])   # GDX-FOR sensors: 1 - force sensor, 2 - x axis accel, 3 - y axis accel, 4 - z axis accel
+gdx.start(period=200)   # data collection period of 200 ms, means a sampling rate of 5 samples/second
+
+# create vpython objects for the ring and each force, as well as labels for the forces
+obj = ring(axis=vector(0,0,1),radius=0.5,thickness=0.1,color=color.blue)
+Pointer_hm = arrow (pos=vector(0,-1.1,0),axis=vector(0,-1,0),length=hanging_mass*9.8,color=color.red)
+Label_hm = label(text='<i><b>F</i></b><sub>hanging mass</sub> = '+str(round(9.8*hanging_mass,2))+' N @ 270°',color=color.red,pos=Pointer_hm.pos,xoffset=10,yoffset=-10,box=False,line=False)
+Pointer_gdx = arrow(color=color.green)
+Label_gdx=label(text='<i><b>F</i></b><sub>GDX-FOR</sub>',color=color.green,pos=Pointer_gdx.pos,xoffset=50,yoffset=20,box=False,line=False)
+Pointer_string = arrow(color=color.yellow)
+Label_string=label(text='<i><b>F</i></b><sub>string</sub>',color=color.yellow,pos=Pointer_string.pos,xoffset=-50,yoffset=20,box=False,line=False)
+
+# data collection loop, runs for 100 samples or 20 seconds (with a 200 ms period -> see line 27)
+for i in range(0,100):
+    # get force and direction measurements from GDX-FOR
+    measurements = gdx.read()
+    if measurements == None:
+        break
+    print(measurements)
+    force_reading = measurements[0] # sensor channel 1 is force (in Newtons)
+    direction = vector(-measurements[2],-measurements[1],measurements[3])   # use the accelerometer values to create a vector for the force exerted by the force sensor
+    f_gdx = force_reading*direction.norm()  # vector that represents the force exerted by the force sensor
+    # update the GDX-FOR arrow in the freebody diagram
+    Pointer_gdx.axis=f_gdx.norm()
+    Pointer_gdx.pos=f_gdx/f_gdx.mag
+    Pointer_gdx.length=f_gdx.mag
+    Angle_gdx=math.atan2(direction.y,direction.x)*180/math.pi
+    Label_gdx.text='<i><b>F</i></b><sub>GDX-FOR</sub> = '+str(round(force_reading,2))+' N @ '+str(round(Angle_gdx,2))+'°'
+
+    # define the hanging mass vector
+    f_hm = vector(0,-9.8*hanging_mass,0)
+    # update the hanging mass arrow in the freebody diagram
+    Pointer_hm.axis=f_hm.norm()
+    Pointer_hm.pos=vector(0,-1.1,0)
+    Pointer_hm.length=f_hm.mag
+
+    # calculate the force/direction exerted by the string
+    f_string = -(f_gdx+f_hm)    # python does the vector addition, no need to separate into components
+    # update the string arrow in the freebody-diagram
+    Pointer_string.axis=f_string.norm()
+    Pointer_string.pos=f_string/f_string.mag
+    Pointer_string.length=f_string.mag
+    Angle_string=math.atan2(Pointer_string.axis.y,Pointer_string.axis.x)*180/math.pi
+    Label_string.text='<i><b>F</i></b><sub>string</sub> = '+str(round(f_string.mag,2))+' N @ '+str(round(Angle_string,2))+'°'
+    
+        
+gdx.stop() 
+gdx.close() 
+

--- a/python/advanced_examples/readme.md
+++ b/python/advanced_examples/readme.md
@@ -1,0 +1,9 @@
+# Advanced Examples
+
+The examples in this folder demonstrate some more advanced uses of Go Direct devices and Python. Most of these examples use the local module named `gdx` that can be found in the [../gdx/](../gdx) folder. Many of these examples may also require that you install other dependencies to get them to work. You should be able to use `pip` to install these, as needed.
+
+## License
+
+All of the content in this repository is available under the terms of the [BSD 3-Clause License](../LICENSE).
+
+Vernier products are designed for educational use. Our products are not designed nor are they recommended for any industrial, medical, or commercial process such as life support, patient diagnosis, control of a manufacturing process, or industrial testing of any kind.

--- a/python/readme.md
+++ b/python/readme.md
@@ -4,6 +4,8 @@ If you are new to Python, you may want to visit our [Getting started with Go Dir
 
 The examples in this folder will walk you through some of the basics of talking to a Go Direct device using Python. Under the hood, they all use the the [godirect module](https://pypi.org/project/godirect/) to communicate with the Go Direct devices. However, to make things a bit simpler, we created a layer to abstract some of the details away and provide cleaner paths to the most common functions. That layer is named `gdx` and can be found in the [/gdx/](./gdx) folder. All of the examples in this folder make use of it for a cleaner, simpler entry point into coding with Go Direct devices.
 
+For other ideas and more advanced examples, take a look in the [/advanced_examples/](./advanced/examples) folder.
+
 ## Example 1: User Prompts and Collecting Data
 
 The [gdx_getting_started_1.py](https://github.com/VernierST/godirect-examples/blob/master/python/gdx_getting_started_1.py) example shows you how to use the gdx functions to:


### PR DESCRIPTION
The new advanced_examples folder is meant to hold new examples that we (or outside users) provide. This segregation is helpful for keeping the getting_started examples by themselves at the top level of the python folder. Also of note, this particular example uses the 'gdx' module, but is not in the same folder, so we use a little trick to allow it to import the gdx module from a sub-folder.